### PR TITLE
`executor` as ApiHandle class attribute

### DIFF
--- a/jupyter_resource_usage/api.py
+++ b/jupyter_resource_usage/api.py
@@ -14,13 +14,7 @@ except ImportError:
 
 
 class ApiHandler(APIHandler):
-    def initialize(self):
-        self.executor = ThreadPoolExecutor(max_workers=5)
-
-    def __del__(self):
-        # Ensure the executor is properly shutdown
-        self.executor.shutdown(wait=False)
-        super().__del__()
+    executor = ThreadPoolExecutor(max_workers=5)
 
     @web.authenticated
     async def get(self):


### PR DESCRIPTION
Follow-up to #93 

Trying the latest locally, there seems to be a couple of warnings related to having the `__del__` method:

```bash
Exception ignored in: <function ApiHandler.__del__ at 0x7ff024d01040>
Traceback (most recent call last):
  File "/path/to/miniforge3/envs/jupyter-resource-usage-release/lib/python3.9/site-packages/jupyter_resource_usage/api.py", line 23, in __del__
    super().__del__()
AttributeError: 'super' object has no attribute '__del__'

```

Looks like it should be fine to keep the previous behavior of having the executor as a class attribute.

cc @fcollonval 