### PR TITLE
Ensure we use backoff when request fails

### DIFF
--- a/packages/labextension/src/memoryUsage.tsx
+++ b/packages/labextension/src/memoryUsage.tsx
@@ -336,10 +336,6 @@ namespace Private {
     );
     const response = await request;
 
-    if (response.ok) {
-      return await response.json();
-    }
-
-    return null;
+    return await response.json();
   }
 }

--- a/packages/labextension/src/memoryUsage.tsx
+++ b/packages/labextension/src/memoryUsage.tsx
@@ -93,7 +93,7 @@ export namespace MemoryUsage {
      */
     constructor(options: Model.IOptions) {
       super();
-      this._poll = new Poll<Private.IMetricRequestResult | null>({
+      this._poll = new Poll<Private.IMetricRequestResult>({
         factory: () => Private.factory(),
         frequency: {
           interval: options.refreshRate,
@@ -216,7 +216,7 @@ export namespace MemoryUsage {
     private _currentMemory = 0;
     private _memoryLimit: number | null = null;
     private _metricsAvailable = false;
-    private _poll: Poll<Private.IMetricRequestResult | null>;
+    private _poll: Poll<Private.IMetricRequestResult>;
     private _units: MemoryUnit = 'B';
     private _warn = false;
   }
@@ -328,7 +328,7 @@ namespace Private {
   /**
    * Make a request to the backend.
    */
-  export async function factory(): Promise<IMetricRequestResult | null> {
+  export async function factory(): Promise<IMetricRequestResult> {
     const request = ServerConnection.makeRequest(
       METRIC_URL,
       {},


### PR DESCRIPTION
Currently, the exponential backoff feature of the `Poll` class is not used since we never throw an error for a bad network request (e.g. a 404).

This is demonstrated by the fact that the frontend extension will keep hitting a 404 every 5 seconds if you disable the server extension.

As can be seen from the lumino code, we need to raise an exception to trigger the backoff code. Simply returning null doesn't do anything:
https://github.com/jupyterlab/lumino/blob/8567deefe4dd2c84b3bd22da5c8151941cd3b2db/packages/polling/src/poll.ts#L319-L329