### PR TITLE
catch psutil exceptions

### DIFF
--- a/jupyter_resource_usage/api.py
+++ b/jupyter_resource_usage/api.py
@@ -27,7 +27,12 @@ class ApiHandler(APIHandler):
         all_processes = [cur_process] + cur_process.children(recursive=True)
 
         # Get memory information
-        rss = sum([p.memory_info().rss for p in all_processes])
+        rss = 0
+        for p in all_processes:
+            try:
+               rss += p.memory_info().rss
+            except (psutil.NoSuchProcess, AccessDenied) as e:
+               pass
 
         if callable(config.mem_limit):
             mem_limit = config.mem_limit(rss=rss)

--- a/jupyter_resource_usage/api.py
+++ b/jupyter_resource_usage/api.py
@@ -31,7 +31,7 @@ class ApiHandler(APIHandler):
         for p in all_processes:
             try:
                rss += p.memory_info().rss
-            except (psutil.NoSuchProcess, AccessDenied) as e:
+            except (psutil.NoSuchProcess, psutil.AccessDenied) as e:
                pass
 
         if callable(config.mem_limit):

--- a/jupyter_resource_usage/api.py
+++ b/jupyter_resource_usage/api.py
@@ -30,9 +30,9 @@ class ApiHandler(APIHandler):
         rss = 0
         for p in all_processes:
             try:
-               rss += p.memory_info().rss
+                rss += p.memory_info().rss
             except (psutil.NoSuchProcess, psutil.AccessDenied) as e:
-               pass
+                pass
 
         if callable(config.mem_limit):
             mem_limit = config.mem_limit(rss=rss)


### PR DESCRIPTION
This MR fixes the issue that process collected in 
`all_processes = [cur_process] + cur_process.children(recursive=True)`
can be invalid in the next line when summing their memory resources.
`rss = sum([p.memory_info().rss for p in all_processes])`

The psutil documentation mentions this as a side-note:
["When accessing methods of this class always be prepared to catch NoSuchProcess and AccessDenied exceptions."](https://psutil.readthedocs.io/en/latest/index.html?#psutil.Process)

(this is not a theoretical issue - we could see this problem at our site and were therefore tracking it down to fix it)