### PR TITLE
Fix update at zero cpu

### DIFF
--- a/jupyter_resource_usage/static/main.js
+++ b/jupyter_resource_usage/static/main.js
@@ -74,7 +74,7 @@ define([
 
                 // Handle CPU display
                 var cpuPercent = data['cpu_percent'];
-                if (cpuPercent) {
+                if (cpuPercent !== undefined) {
                     // Remove hide CSS class if the metrics API gives us a CPU percent to display
                     $('#jupyter-resource-usage-display-cpu').removeClass('jupyter-resource-usage-hide');
                     var maxCpu = data['cpu_count'];


### PR DESCRIPTION
I encountered what seems to be a bug in `jupyter-resource-usage`. The CPU percentage would not be updated, unless we were actually executing code. The result of this was that, after cells had completed and the CPU was idling (0% CPU usage), the displayed percentage would be stuck at the last non-zero value.

I traced the cause to [this line](https://github.com/jupyter-server/jupyter-resource-usage/blob/799343d066c9c828e079c3916ff1f8d155b0be1f/jupyter_resource_usage/static/main.js#L77). Most likely, the intend there was to make sure the CPU usage wasn't displayed if the API endpoint didn't register a CPU usage (i.e. if `data` didn't contain the `cpu_percent` key). However, `if (cpuPercent)` _also_ evaluates to `False` in Javascript if `cpuPercent=0`. That caused the lack of updates whenever `cpuPercent=0`.

The current fix explicitly checks if they keyword was found by checking that `data[cpu_percent]` was _not_ equal to the `undefined` constant.