### PR TITLE
Define _jupyter_server_extension_paths for backward compatibility

### DIFF
--- a/jupyter_resource_usage/__init__.py
+++ b/jupyter_resource_usage/__init__.py
@@ -35,4 +35,6 @@ def _jupyter_nbextension_paths():
     ]
 
 
-load_jupyter_server_extension = load_jupyter_server_extension
+# For backward compatibility
+_load_jupyter_server_extension = load_jupyter_server_extension
+_jupyter_server_extension_paths = _jupyter_server_extension_points


### PR DESCRIPTION
Fix #91 by defining _load_jupyter_server_extension for further backward compatibility (see https://jupyter-server.readthedocs.io/en/latest/developers/extensions.html#migrating-an-extension-to-use-jupyter-server)

This PR replaces https://github.com/jupyter-server/jupyter-resource-usage/pull/134