### PR TITLE
Use `pss` if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ causes "lag"/pauses in the UI. To workaround this you can disable Prometheus met
 
 ## Resources Displayed
 
-Currently the server extension only reports memory usage (just RSS) and CPU usage. Other metrics will be
-added in the future as needed.
+Currently the server extension only reports memory usage and CPU usage. Other metrics will be added in the future as needed.
+
+Memory usage will show the PSS whenever possible (Linux only feature), and default to RSS otherwise.
 
 The notebook extension currently doesn't show CPU usage, only memory usage.
 

--- a/jupyter_resource_usage/static/main.js
+++ b/jupyter_resource_usage/static/main.js
@@ -60,7 +60,7 @@ define([
                 var display = totalMemoryUsage;
 
                 if (limits['memory']) {
-                    limit = limits['memory']['pss'] || limits['memory']['rss'];
+                    limit = limits['memory']['pss'] ?? limits['memory']['rss'];
                     if (limit) {
                         maxMemoryUsage = humanFileSize(limit);
                         display += " / " + maxMemoryUsage

--- a/jupyter_resource_usage/static/main.js
+++ b/jupyter_resource_usage/static/main.js
@@ -53,14 +53,16 @@ define([
         $.getJSON({
             url: utils.get_body_data('baseUrl') + 'api/metrics/v1',
             success: function (data) {
-                totalMemoryUsage = humanFileSize(data['rss']);
+                value = data['pss'] || data['rss'];
+                totalMemoryUsage = humanFileSize(value);
 
                 var limits = data['limits'];
                 var display = totalMemoryUsage;
 
                 if (limits['memory']) {
-                    if (limits['memory']['rss']) {
-                        maxMemoryUsage = humanFileSize(limits['memory']['rss']);
+                    limit = limits['memory']['pss'] || limits['memory']['rss'];
+                    if (limit) {
+                        maxMemoryUsage = humanFileSize(limit);
                         display += " / " + maxMemoryUsage
                     }
                     if (limits['memory']['warn']) {

--- a/packages/labextension/src/memoryUsage.tsx
+++ b/packages/labextension/src/memoryUsage.tsx
@@ -180,10 +180,9 @@ export namespace MemoryUsage {
         this._units = 'B';
         this._warn = false;
       } else {
-        const numBytes = value.rss;
-        const memoryLimit = value.limits.memory
-          ? value.limits.memory.rss
-          : null;
+        const numBytes = value.pss ?? value.rss;
+        const memoryLimits = value.limits.memory;
+        const memoryLimit = memoryLimits?.pss ?? memoryLimits?.rss ?? null;
         const [currentMemory, units] = convertToLargestUnit(numBytes);
         const usageWarning = value.limits.memory
           ? value.limits.memory.warn
@@ -260,9 +259,11 @@ namespace Private {
    */
   export interface IMetricRequestResult {
     rss: number;
+    pss?: number;
     limits: {
       memory?: {
         rss: number;
+        pss?: number;
         warn: boolean;
       };
     };


### PR DESCRIPTION
Fixes https://github.com/jupyter-server/jupyter-resource-usage/issues/130

- [x] Send `pss` if available: mimic https://github.com/ipython/ipykernel/issues/935
- [x] Add `pss` to the API response so it doesn't break existing frontends reading `rss`
- [x] Update the default JupyterLab and Classic Notebook extensions shipped in `jupyter-resource-usage` to read `pss` first and default to `rss` otherwise
- [x] Update `README.md` to mention this