### PR TITLE
Stop all channels to allow ZMQContext to properly cleanup between calls

### DIFF
--- a/jupyter_resource_usage/api.py
+++ b/jupyter_resource_usage/api.py
@@ -122,14 +122,13 @@ class KernelUsageHandler(APIHandler):
         timeout_ms = 10_000
         events = dict(await poller.poll(timeout_ms))
         if control_socket not in events:
-            self.write(
-                json.dumps(
-                    {
-                        "content": {"reason": "timeout", "timeout_ms": timeout_ms},
-                        "kernel_id": kernel_id,
-                    }
-                )
+            out = json.dumps(
+                {
+                    "content": {"reason": "timeout", "timeout_ms": timeout_ms},
+                    "kernel_id": kernel_id,
+                }
             )
+
         else:
             res = client.control_channel.get_msg(timeout=0)
             if isawaitable(res):
@@ -138,4 +137,6 @@ class KernelUsageHandler(APIHandler):
                 res = await res
             if res:
                 res["kernel_id"] = kernel_id
-            self.write(json.dumps(res, default=date_default))
+            out = json.dumps(res, default=date_default)
+        client.stop_channels()
+        self.write(out)


### PR DESCRIPTION
Fixes #182.