### PR TITLE
enhancement: Track disk utilization in $HOME

### DIFF
--- a/jupyter_resource_usage/api.py
+++ b/jupyter_resource_usage/api.py
@@ -1,4 +1,5 @@
 import json
+import os
 from concurrent.futures import ThreadPoolExecutor
 from inspect import isawaitable
 
@@ -60,6 +61,11 @@ class ApiHandler(APIHandler):
         metrics = {"rss": rss, "limits": limits}
         if pss is not None:
             metrics["pss"] = pss
+
+        if config.track_disk_usage:
+            disk_info = psutil.disk_usage(os.getenv("HOME"))
+            metrics["disk_used"] = disk_info.used
+            metrics["disk_total"] = disk_info.total
 
         # Optionally get CPU information
         if config.track_cpu_percent:

--- a/jupyter_resource_usage/config.py
+++ b/jupyter_resource_usage/config.py
@@ -37,6 +37,11 @@ class ResourceUseDisplay(Configurable):
     Holds server-side configuration for jupyter-resource-usage
     """
 
+    system_disk_metrics = List(
+        trait=PSUtilMetric(),
+        default_value=[{"name": "disk_usage", "attribute": "disk_used"}],
+    )
+
     process_memory_metrics = List(
         trait=PSUtilMetric(),
         default_value=[{"name": "memory_info", "attribute": "rss"}],
@@ -127,5 +132,12 @@ class ResourceUseDisplay(Configurable):
         default_value=True,
         help="""
         Set to False in order to disable reporting of Prometheus style metrics.
+        """,
+    ).tag(config=True)
+
+    track_disk_usage = Bool(
+        default_value=False,
+        help="""
+        Set to True in order to enable reporting of disk usage statistics.
         """,
     ).tag(config=True)

--- a/jupyter_resource_usage/metrics.py
+++ b/jupyter_resource_usage/metrics.py
@@ -80,3 +80,6 @@ class PSUtilMetricsLoader:
         return self.metrics(
             self.config.process_cpu_metrics, self.config.system_cpu_metrics
         )
+
+    def disk_metrics(self):
+        return self.metrics(self.config.system_disk_metrics)

--- a/packages/labextension/src/memoryView.tsx
+++ b/packages/labextension/src/memoryView.tsx
@@ -20,11 +20,11 @@ const MemoryViewComponent = ({
   const [values, setValues] = useState<number[]>([]);
 
   const update = (): void => {
-    const { memoryLimit, currentMemory, units } = model;
-    const precision = ['B', 'KB', 'MB'].indexOf(units) > 0 ? 0 : 2;
+    const { memoryLimit, currentMemory, memoryUnits } = model;
+    const precision = ['B', 'KB', 'MB'].indexOf(memoryUnits) > 0 ? 0 : 2;
     const newText = `${currentMemory.toFixed(precision)} ${
       memoryLimit ? '/ ' + memoryLimit.toFixed(precision) : ''
-    } ${units}`;
+    } ${memoryUnits}`;
     const newValues = model.values.map((value) => value.memoryPercent);
     setText(newText);
     setValues(newValues);

--- a/packages/labextension/src/resourceUsage.tsx
+++ b/packages/labextension/src/resourceUsage.tsx
@@ -37,15 +37,24 @@ export class ResourceUsageStatus extends VDomRenderer<ResourceUsage.Model> {
       text = this._trans.__(
         'Mem: %1 %2',
         this.model.currentMemory.toFixed(Private.DECIMAL_PLACES),
-        this.model.units
+        this.model.memoryUnits
       );
     } else {
       text = this._trans.__(
         'Mem: %1 / %2 %3',
         this.model.currentMemory.toFixed(Private.DECIMAL_PLACES),
         this.model.memoryLimit.toFixed(Private.DECIMAL_PLACES),
-        this.model.units
+        this.model.memoryUnits
       );
+    }
+
+    if (this.model.diskAvailable && this.model.diskTotal !== null) {
+      text = `${text} ${this._trans.__(
+        'Disk: %1 / %2 %3',
+        this.model.diskUsed.toFixed(Private.DECIMAL_PLACES),
+        this.model.diskTotal.toFixed(Private.DECIMAL_PLACES),
+        this.model.diskUnits
+      )}`;
     }
     if (this.model.cpuAvailable) {
       text = `CPU: ${(this.model.currentCpuPercent * 100).toFixed(


### PR DESCRIPTION
We extended j-r-u for monitoring disk usage in $HOME for our service.  Looks like at least one other person was interested in something similar: https://github.com/jupyter-server/jupyter-resource-usage/issues/186

