### PR TITLE
Handle `currentWidget` in `KernelWidgetTracker`

### DIFF
--- a/packages/labextension/src/index.ts
+++ b/packages/labextension/src/index.ts
@@ -169,8 +169,8 @@ const kernelUsagePlugin: JupyterFrontEndPlugin<void> = {
         });
 
         panel = new KernelUsagePanel({
-          currentChanged: tracker.currentChanged,
-          trans: trans,
+          tracker,
+          trans,
         });
         shell.add(panel, 'right', { rank: 200 });
       }

--- a/packages/labextension/src/panel.ts
+++ b/packages/labextension/src/panel.ts
@@ -1,10 +1,8 @@
 import { Message } from '@lumino/messaging';
-import { ISignal } from '@lumino/signaling';
 import { TranslationBundle } from '@jupyterlab/translation';
 import { StackedPanel } from '@lumino/widgets';
 import { LabIcon } from '@jupyterlab/ui-components';
 import { KernelUsageWidget } from './widget';
-import { IWidgetWithSession } from './types';
 import { KernelWidgetTracker } from './tracker';
 
 import tachometer from '../style/tachometer.svg';
@@ -13,7 +11,7 @@ const PANEL_CLASS = 'jp-KernelUsage-view';
 
 export class KernelUsagePanel extends StackedPanel {
   constructor(props: {
-    currentChanged: ISignal<KernelWidgetTracker, IWidgetWithSession | null>;
+    tracker: KernelWidgetTracker;
     trans: TranslationBundle;
   }) {
     super();
@@ -27,7 +25,7 @@ export class KernelUsagePanel extends StackedPanel {
     this.title.closable = true;
 
     const widget = new KernelUsageWidget({
-      currentChanged: props.currentChanged,
+      tracker: props.tracker,
       panel: this,
       trans: props.trans,
     });

--- a/packages/labextension/src/tracker.ts
+++ b/packages/labextension/src/tracker.ts
@@ -16,20 +16,26 @@ export class KernelWidgetTracker {
         const widget = update.newValue;
         if (widget && hasKernelSession(widget)) {
           this._currentChanged.emit(widget);
+          this._currentWidget = widget;
         } else {
           this._currentChanged.emit(null);
+          this._currentWidget = null;
         }
       });
     } else {
       notebookTracker.currentChanged.connect((_, widget) => {
         this._currentChanged.emit(widget);
+        this._currentWidget = widget;
       });
       if (consoleTracker) {
         consoleTracker.currentChanged.connect((_, widget) => {
           this._currentChanged.emit(widget);
+          this._currentWidget = widget;
         });
       }
     }
+    this._currentWidget =
+      notebookTracker.currentWidget ?? consoleTracker?.currentWidget ?? null;
   }
 
   /**
@@ -44,10 +50,16 @@ export class KernelWidgetTracker {
     return this._currentChanged;
   }
 
+  get currentWidget(): IWidgetWithSession | null {
+    return this._currentWidget;
+  }
+
   private _currentChanged: Signal<
     KernelWidgetTracker,
     IWidgetWithSession | null
   >;
+
+  private _currentWidget: IWidgetWithSession | null = null;
 }
 
 /**

--- a/packages/labextension/src/tracker.ts
+++ b/packages/labextension/src/tracker.ts
@@ -34,8 +34,15 @@ export class KernelWidgetTracker {
         });
       }
     }
-    this._currentWidget =
-      notebookTracker.currentWidget ?? consoleTracker?.currentWidget ?? null;
+    // handle an existing current widget in case the KernelWidgetTracker
+    // is created a bit later, or if there is already a Notebook widget available
+    // on page load like in Notebook 7.
+    if (labShell?.currentWidget && hasKernelSession(labShell?.currentWidget)) {
+      this._currentWidget = labShell.currentWidget;
+    } else {
+      this._currentWidget =
+        notebookTracker.currentWidget ?? consoleTracker?.currentWidget ?? null;
+    }
   }
 
   /**


### PR DESCRIPTION
FIxes https://github.com/jupyter-server/jupyter-resource-usage/issues/204

The tracker now keeps track of the `currentWidget`. This is useful in the case of Notebook 7 where connecting to `currentChanged` might not be enough. Notebook 7 adds the notebook widget to the page very early, and the kernel usage component might be connecting to `tracker.currentChanged` *after* the `tracker.currentChanged` is emitted.

https://github.com/jupyter-server/jupyter-resource-usage/assets/591645/ac0075ca-12ad-44c4-bf7f-e4e5ac6cc4d7