### PR TITLE
Add Notebook 7 to Binder

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -4,4 +4,5 @@ channels:
 dependencies:
 - python=3
 - jupyterlab=4
+- notebook=7
 - nodejs=18


### PR DESCRIPTION
Add Notebook 7 to Binder so the extension can also be tested with Notebook 7 easily.