### PR TITLE
Adds custom config to show/hide host usage info

### DIFF
--- a/jupyter_resource_usage/api.py
+++ b/jupyter_resource_usage/api.py
@@ -106,6 +106,8 @@ class KernelUsageHandler(APIHandler):
             )
             return
 
+        config = self.settings["jupyter_resource_usage_display_config"]
+
         kernel_id = matched_part
         km = self.kernel_manager
         lkm = km.pinned_superclass.get_kernel(km, kernel_id)
@@ -114,7 +116,6 @@ class KernelUsageHandler(APIHandler):
 
         control_channel = client.control_channel
         usage_request = session.msg("usage_request", {})
-
         control_channel.send(usage_request)
         poller = zmq.asyncio.Poller()
         control_socket = control_channel.socket
@@ -137,6 +138,7 @@ class KernelUsageHandler(APIHandler):
                 res = await res
             if res:
                 res["kernel_id"] = kernel_id
+            res["content"].update({"host_usage_flag": config.show_host_usage})
             out = json.dumps(res, default=date_default)
         client.stop_channels()
         self.write(out)

--- a/jupyter_resource_usage/config.py
+++ b/jupyter_resource_usage/config.py
@@ -129,3 +129,10 @@ class ResourceUseDisplay(Configurable):
         Set to False in order to disable reporting of Prometheus style metrics.
         """,
     ).tag(config=True)
+
+    show_host_usage = Bool(
+        default_value=True,
+        help="""
+        Set to True in order to show host cpu and host virtual memory info.
+        """,
+    ).tag(config=True)

--- a/packages/labextension/src/widget.tsx
+++ b/packages/labextension/src/widget.tsx
@@ -19,6 +19,7 @@ type Usage = {
   pid: number;
   host_cpu_percent: number;
   cpu_count: number;
+  host_usage_flag: boolean;
   host_virtual_memory: {
     active: number;
     available: number;
@@ -302,56 +303,56 @@ const KernelUsage = (props: {
                 {formatForDisplay(usage.kernel_memory)}
               </div>
               <hr className="jp-KernelUsage-section-separator"></hr>
-              <h4 className="jp-KernelUsage-section-separator">
-                {props.trans.__('Host CPU')}
-              </h4>
-              {usage.host_cpu_percent && (
-                <div className="jp-KernelUsage-separator">
-                  {props.trans._n(
-                    '%2%% used on %1 CPU',
-                    '%2%% used on %1 CPUs',
-                    usage.cpu_count,
-                    usage.host_cpu_percent.toFixed(1)
+              {usage?.host_usage_flag ? (
+                <>
+                  <h4 className="jp-KernelUsage-section-separator">
+                    {props.trans.__('Host CPU')}
+                  </h4>
+                  {usage.host_cpu_percent && (
+                    <div className="jp-KernelUsage-separator">
+                      {props.trans._n(
+                        '%2%% used on %1 CPU',
+                        '%2%% used on %1 CPUs',
+                        usage.cpu_count,
+                        usage.host_cpu_percent.toFixed(1)
+                      )}
+                    </div>
                   )}
-                </div>
-              )}
-              <h4 className="jp-KernelUsage-section-separator">
-                {props.trans.__('Host Virtual Memory')}
-              </h4>
-              <div className="jp-KernelUsage-separator">
-                {props.trans.__('Active:')}{' '}
-                {formatForDisplay(usage.host_virtual_memory.active)}
-              </div>
-              <div className="jp-KernelUsage-separator">
-                {props.trans.__('Available:')}{' '}
-                {formatForDisplay(usage.host_virtual_memory.available)}
-              </div>
-              <div className="jp-KernelUsage-separator">
-                {props.trans.__('Free:')}{' '}
-                {formatForDisplay(usage.host_virtual_memory.free)}
-              </div>
-              <div className="jp-KernelUsage-separator">
-                {props.trans.__('Inactive:')}{' '}
-                {formatForDisplay(usage.host_virtual_memory.inactive)}
-              </div>
-              {usage.host_virtual_memory.percent && (
-                <div className="jp-KernelUsage-separator">
-                  {props.trans.__('Percent used:')}{' '}
-                  {usage.host_virtual_memory.percent.toFixed(1)}%
-                </div>
-              )}
-              <div className="jp-KernelUsage-separator">
-                {props.trans.__('Total:')}{' '}
-                {formatForDisplay(usage.host_virtual_memory.total)}
-              </div>
-              <div className="jp-KernelUsage-separator">
-                {props.trans.__('Used:')}{' '}
-                {formatForDisplay(usage.host_virtual_memory.used)}
-              </div>
-              <div className="jp-KernelUsage-separator">
-                {props.trans.__('Wired:')}{' '}
-                {formatForDisplay(usage.host_virtual_memory.wired)}
-              </div>
+                  <h4 className="jp-KernelUsage-section-separator">
+                    {props.trans.__('Host Virtual Memory')}
+                  </h4>
+                  <div className="jp-KernelUsage-separator">
+                    {props.trans.__('Active:')}{' '}
+                    {formatForDisplay(usage.host_virtual_memory.active)}
+                  </div>
+                  <div className="jp-KernelUsage-separator">
+                    {props.trans.__('Available:')}{' '}
+                    {formatForDisplay(usage.host_virtual_memory.available)}
+                  </div>
+                  <div className="jp-KernelUsage-separator">
+                    {props.trans.__('Free:')}{' '}
+                    {formatForDisplay(usage.host_virtual_memory.free)}
+                  </div>
+                  <div className="jp-KernelUsage-separator">
+                    {props.trans.__('Inactive:')}{' '}
+                    {formatForDisplay(usage.host_virtual_memory.inactive)}
+                  </div>
+                  {usage.host_virtual_memory.percent && (
+                    <div className="jp-KernelUsage-separator">
+                      {props.trans.__('Percent used:')}{' '}
+                      {usage.host_virtual_memory.percent.toFixed(1)}%
+                    </div>
+                  )}
+                  <div className="jp-KernelUsage-separator">
+                    {props.trans.__('Total:')}{' '}
+                    {formatForDisplay(usage.host_virtual_memory.total)}
+                  </div>
+                  <div className="jp-KernelUsage-separator">
+                    {props.trans.__('Wired:')}{' '}
+                    {formatForDisplay(usage.host_virtual_memory.wired)}
+                  </div>
+                </>
+              ) : null}
             </>
           ) : blankStateReason?.reason === 'loading' ? (
             <div className="jp-KernelUsage-separator">


### PR DESCRIPTION
### Objective
This PR includes the changes to add a custom configuration to show or hide the Host CPU and Host Virtual Memory information (Issue: #209) . It is added as a config parameter, and can be set as:
`c.ResourceUseDisplay.show_host_usage=False` (if you want to hide the host usage info, default is set as True)

### How to test
Follow the set up process from [`contributing.md`](https://github.com/jupyter-server/jupyter-resource-usage/blob/e6f707bd0b70b06d53ea68c411203de377d72767/CONTRIBUTING.md) or use the following commands:

```
# Create a virtual environment using tool that you like. I used conda.
conda create -n jupyter-resource-usage -c conda-forge python

# activate the environment (conda, pipenv)
conda activate jupyter-resource-usage

# install the package in development mode
python -m pip install -e ".[dev]"

# link your development version of the extension with JupyterLab
jupyter labextension develop . --overwrite

# go to the labextension directory
cd packages/labextension/

# Rebuild extension Typescript source after making changes
jlpm run build

# Watch the source directory in one terminal, automatically rebuilding when needed
jlpm run watch
# Run JupyterLab in another terminal
jupyter lab --ResourceUseDisplay.show_host_usage=False
```
When you click the sidebar or tachometer, you should only see the Kernel usage as shown below:
![image](https://github.com/jupyter-server/jupyter-resource-usage/assets/11097488/68614ac7-bce5-43f2-ae1e-295c0fb4367d)

When you set the `show_host_usage=True`, you should see all the info.


 