### PR TITLE
Fix typo in default username for jupyter

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ c = get_config()
 c.ResourceUseDisplay.track_disk_usage = True
 ```
 
-The values are from the partition containing the folder in the trait `disk_path` (which defaults to `/home/joyvan`). If this path does not exist, disk usage information is omitted from the display.
+The values are from the partition containing the folder in the trait `disk_path` (which defaults to `/home/jovyan`). If this path does not exist, disk usage information is omitted from the display.
 
 Mirroring CPU and Memory, the trait `disk_warning_threshold` signifies when to flag a usage warning, and like the others, it defaults to `0.1` (10% remaining)
 

--- a/jupyter_resource_usage/config.py
+++ b/jupyter_resource_usage/config.py
@@ -41,7 +41,7 @@ class ResourceUseDisplay(Configurable):
     # Needs to be defined early, so the metrics can use it.
     disk_path = Union(
         trait_types=[Unicode(), Callable()],
-        default_value="/home/joyvan",
+        default_value="/home/jovyan",
         help="""
         A path in the partition to be reported on.
         """,
@@ -155,7 +155,7 @@ class ResourceUseDisplay(Configurable):
 
     @default("disk_path")
     def _disk_path_default(self):
-        return str(os.environ.get("HOME", "/home/joyvan"))
+        return str(os.environ.get("HOME", "/home/jovyan"))
 
     disk_warning_threshold = Float(
         default_value=0.1,


### PR DESCRIPTION
Fix typo in default username for jupyter, in the default configuration value, in the documentation.

Closes #238