### PR TITLE
opt-in for enable_prometheus_metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,10 @@ Mirroring CPU and Memory, the trait `disk_warning_threshold` signifies when to f
 ### Disable Prometheus Metrics
 
 There is a [known bug](https://github.com/jupyter-server/jupyter-resource-usage/issues/123) with Prometheus metrics which
-causes "lag"/pauses in the UI. Hence, the Prometheus metric reporting is disabled by default (for all versions > 1.1.1).  
+causes "lag"/pauses in the UI. Hence, the Prometheus metric reporting is disabled by default (for all versions > 1.1.1).
+
 If you want to use the Prometheus metric reporting you need to enable it with:
+
 ```
 --ResourceUseDisplay.enable_prometheus_metrics=True
 ```

--- a/README.md
+++ b/README.md
@@ -162,10 +162,10 @@ Mirroring CPU and Memory, the trait `disk_warning_threshold` signifies when to f
 ### Disable Prometheus Metrics
 
 There is a [known bug](https://github.com/jupyter-server/jupyter-resource-usage/issues/123) with Prometheus metrics which
-causes "lag"/pauses in the UI. To workaround this you can disable Prometheus metric reporting using:
-
+causes "lag"/pauses in the UI. Hence, the Prometheus metric reporting is disabled by default (for all versions > 1.1.1).  
+If you want to use the Prometheus metric reporting you need to enable it with:
 ```
---ResourceUseDisplay.enable_prometheus_metrics=False
+--ResourceUseDisplay.enable_prometheus_metrics=True
 ```
 
 ## Enable alternative frontend

--- a/jupyter_resource_usage/config.py
+++ b/jupyter_resource_usage/config.py
@@ -171,7 +171,7 @@ class ResourceUseDisplay(Configurable):
     ).tag(config=True)
 
     enable_prometheus_metrics = Bool(
-        default_value=True,
+        default_value=False,
         help="""
         Set to False in order to disable reporting of Prometheus style metrics.
         """,


### PR DESCRIPTION
I would suggest to change that to an `opt-in`.

At the moment jupyter-resource-usage is overloading tornado's task-pool for the prometheus-feature without taking into account that this will result in less (or even worst) performance for the critical webserver.

More details can be found here: https://github.com/jupyter-server/jupyter-resource-usage/issues/242
