### PR TITLE
Configure `standby` callback to polling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Base Setup
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -14,7 +14,7 @@ jobs:
   check_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Check Release
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.9", "3.13"]
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Base Setup
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
@@ -37,6 +37,6 @@ jobs:
   check_links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1

--- a/jupyter_resource_usage/api.py
+++ b/jupyter_resource_usage/api.py
@@ -95,7 +95,7 @@ class ApiHandler(APIHandler):
     def _get_cpu_percent(self, all_processes):
         def get_cpu_percent(p):
             try:
-                return p.cpu_percent(interval=0.05)
+                return p.cpu_percent()
             # Avoid littering logs with stack traces complaining
             # about dead processes having no CPU usage
             except:

--- a/jupyter_resource_usage/tests/test_basic.py
+++ b/jupyter_resource_usage/tests/test_basic.py
@@ -30,13 +30,18 @@ class TestBasic:
         nbapp_mock.web_app.settings = {"base_url": ""}
 
         # mock these out for unit test
-        with patch("tornado.ioloop.PeriodicCallback") as periodic_callback_mock, patch(
-            "jupyter_resource_usage.server_extension.ResourceUseDisplay"
-        ) as resource_use_display_mock, patch(
-            "jupyter_resource_usage.server_extension.PrometheusHandler"
-        ) as prometheus_handler_mock, patch(
-            "jupyter_resource_usage.server_extension.PSUtilMetricsLoader"
-        ) as psutil_metrics_loader:
+        with (
+            patch("tornado.ioloop.PeriodicCallback") as periodic_callback_mock,
+            patch(
+                "jupyter_resource_usage.server_extension.ResourceUseDisplay"
+            ) as resource_use_display_mock,
+            patch(
+                "jupyter_resource_usage.server_extension.PrometheusHandler"
+            ) as prometheus_handler_mock,
+            patch(
+                "jupyter_resource_usage.server_extension.PSUtilMetricsLoader"
+            ) as psutil_metrics_loader,
+        ):
             # load up with mock
             load_jupyter_server_extension(nbapp_mock)
 

--- a/packages/labextension/src/index.ts
+++ b/packages/labextension/src/index.ts
@@ -2,6 +2,7 @@ import {
   ILabShell,
   JupyterFrontEnd,
   JupyterFrontEndPlugin,
+  JupyterLab,
 } from '@jupyterlab/application';
 
 import { IToolbarWidgetRegistry } from '@jupyterlab/apputils';
@@ -70,14 +71,25 @@ const resourceStatusPlugin: JupyterFrontEndPlugin<void> = {
   id: '@jupyter-server/resource-usage:status-item',
   autoStart: true,
   requires: [ITranslator],
-  optional: [IStatusBar],
+  optional: [IStatusBar, JupyterLab.IInfo],
   activate: (
     app: JupyterFrontEnd,
     translator: ITranslator,
-    statusBar: IStatusBar | null
+    statusBar: IStatusBar | null,
+    info: JupyterLab.IInfo
   ) => {
+    const refreshRate = DEFAULT_REFRESH_RATE;
+
     const trans = translator.load('jupyter-resource-usage');
-    const item = new ResourceUsageStatus(trans);
+    const item = new ResourceUsageStatus(trans, {
+      refreshRate,
+      refreshStandby: () => {
+        if (info) {
+          return !info.isConnected || 'when-hidden';
+        }
+        return 'when-hidden';
+      },
+    });
 
     if (statusBar) {
       statusBar.registerStatusItem(resourceStatusPlugin.id, {
@@ -98,11 +110,12 @@ const systemMonitorPlugin: JupyterFrontEndPlugin<void> = {
   id: '@jupyter-server/resource-usage:topbar-item',
   autoStart: true,
   requires: [IToolbarWidgetRegistry],
-  optional: [ISettingRegistry],
+  optional: [ISettingRegistry, JupyterLab.IInfo],
   activate: async (
     app: JupyterFrontEnd,
     toolbarRegistry: IToolbarWidgetRegistry,
-    settingRegistry: ISettingRegistry | null
+    settingRegistry: ISettingRegistry | null,
+    info: JupyterLab.IInfo | null
   ) => {
     let enablePlugin = DEFAULT_ENABLE_SYSTEM_MONITOR;
     let refreshRate = DEFAULT_REFRESH_RATE;
@@ -126,7 +139,15 @@ const systemMonitorPlugin: JupyterFrontEndPlugin<void> = {
       diskLabel = diskSettings.label;
     }
 
-    const model = new ResourceUsage.Model({ refreshRate });
+    const model = new ResourceUsage.Model({
+      refreshRate,
+      refreshStandby: () => {
+        if (info) {
+          return !info.isConnected || 'when-hidden';
+        }
+        return 'when-hidden';
+      },
+    });
     await model.refresh();
 
     if (enablePlugin && model.cpuAvailable) {

--- a/packages/labextension/src/index.ts
+++ b/packages/labextension/src/index.ts
@@ -76,7 +76,7 @@ const resourceStatusPlugin: JupyterFrontEndPlugin<void> = {
     app: JupyterFrontEnd,
     translator: ITranslator,
     statusBar: IStatusBar | null,
-    info: JupyterLab.IInfo
+    info: JupyterLab.IInfo | null
   ) => {
     const refreshRate = DEFAULT_REFRESH_RATE;
 

--- a/packages/labextension/src/model.ts
+++ b/packages/labextension/src/model.ts
@@ -64,8 +64,10 @@ export namespace ResourceUsage {
         frequency: {
           interval: options.refreshRate,
           backoff: true,
+          max: 300 * 1000,
         },
         name: '@jupyterlab/statusbar:ResourceUsage#metrics',
+        standby: options.refreshStandby || 'when-hidden',
       });
       this._poll.ticked.connect((poll) => {
         const { payload, phase } = poll.state;
@@ -326,6 +328,11 @@ export namespace ResourceUsage {
        * The refresh rate (in ms) for querying the server.
        */
       refreshRate: number;
+
+      /**
+       * When the model stops polling the API. Defaults to `when-hidden`.
+       */
+      refreshStandby?: Poll.Standby | (() => boolean | Poll.Standby);
     }
 
     /**

--- a/packages/labextension/src/resourceUsage.tsx
+++ b/packages/labextension/src/resourceUsage.tsx
@@ -20,8 +20,8 @@ export class ResourceUsageStatus extends VDomRenderer<ResourceUsage.Model> {
   /**
    * Construct a new resource usage status item.
    */
-  constructor(trans: TranslationBundle) {
-    super(new ResourceUsage.Model({ refreshRate: 5000 }));
+  constructor(trans: TranslationBundle, options: ResourceUsage.Model.IOptions) {
+    super(new ResourceUsage.Model(options));
     this._trans = trans;
   }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 name = "jupyter-resource-usage"
 description = "Jupyter Extension to show resource usage"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "Jupyter Development Team" },
 ]
@@ -30,15 +30,16 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "jupyter_server>=2.0",
     "prometheus_client",
-    "psutil~=5.6",
+    "psutil>=5.6",
     "pyzmq>=19",
 ]
 dynamic = ["version"]
@@ -126,7 +127,7 @@ default = ""
 
 [tool.jupyter-releaser.hooks]
 before-build-npm = [
-    "python -m pip install jupyterlab~=4.0",
+    "python -m pip install 'jupyterlab>=4.0,<5'",
     "jlpm",
     "jlpm clean",
     "jlpm build:prod",


### PR DESCRIPTION
* The `standby` callback will put poll in standby mode when connection to the server is lost. Useful in JupyterHub deployments. See [discourse](https://discourse.jupyter.org/t/stopping-lumino-poll-when-jupyterlab-server-stops/35280/6) thread.
* Drop support for Python 3.8 and add support for 3.12 and 3.13
* Bump actions versions in CI workflows

Closes #246, #245 

@jtpio Can you please take a look at it when you get some time? Cheers!