### PR TITLE
Added swap used to the memory usage

### DIFF
--- a/jupyter_resource_usage/api.py
+++ b/jupyter_resource_usage/api.py
@@ -42,7 +42,10 @@ class ApiHandler(APIHandler):
                 info = p.memory_full_info()
                 if hasattr(info, "pss"):
                     pss = (pss or 0) + info.pss
-                rss += info.rss
+                if hasattr(info, "swap"):
+                    rss += info.rss + info.swap
+                else:
+                    rss += info.rss
             except (psutil.NoSuchProcess, psutil.AccessDenied) as e:
                 pass
 


### PR DESCRIPTION
When trying to find which open notebook is using a lot of resources, it's misleading to hide the swap value. Users will understand better which notebook is taking up system resources if the RAM+SWAP value is used, since those resources will be freed by closing the notebook.