### PR TITLE
Fix `cpu_percent` always returning 0 in status bar/topbar

### DIFF
--- a/jupyter_resource_usage/api.py
+++ b/jupyter_resource_usage/api.py
@@ -23,6 +23,9 @@ except ImportError:
 
 class ApiHandler(APIHandler):
     executor = ThreadPoolExecutor(max_workers=5)
+    # Cache Process instances so cpu_percent() (without interval) can compare
+    # against the previous measurement instead of always returning 0.
+    _cached_processes = {}
 
     @web.authenticated
     async def get(self):
@@ -33,6 +36,10 @@ class ApiHandler(APIHandler):
 
         cur_process = psutil.Process()
         all_processes = [cur_process] + cur_process.children(recursive=True)
+
+        # Build list using cached Process instances for cpu_percent tracking
+        cached = [ApiHandler._cached_processes.get(p.pid, p) for p in all_processes]
+        ApiHandler._cached_processes = {p.pid: p for p in cached}
 
         # Get memory information
         rss = 0
@@ -64,7 +71,7 @@ class ApiHandler(APIHandler):
         # Optionally get CPU information
         if config.track_cpu_percent:
             cpu_count = psutil.cpu_count()
-            cpu_percent = await self._get_cpu_percent(all_processes)
+            cpu_percent = await self._get_cpu_percent(cached)
 
             if config.cpu_limit != 0:
                 limits["cpu"] = {"cpu": config.cpu_limit}


### PR DESCRIPTION
## Fix `cpu_percent` always returning 0 in status bar/topbar

### Problem

The status bar and topbar widgets always display `0%` CPU usage, while the **Kernel Usage** sidebar correctly reports CPU utilization.

### Root cause

`psutil.Process.cpu_percent()` without an `interval` parameter computes CPU usage relative to the previous call on the **same** `Process` instance. In the current implementation, a new `psutil.Process()` instance is created for every request, so each call is effectively the first call and therefore always returns `0`.

### Solution

Initialize the `Process` instance once and reuse it across requests. This preserves the previous measurement, allowing `cpu_percent()` to return meaningful CPU utilization values in the status bar and topbar.

### Testing

* Deployed on JupyterHub with the fix.
* Verified that CPU usage is now reported correctly in both the status bar and topbar widgets.
* Confirmed that the **Kernel Usage** sidebar continues to report CPU usage correctly.

### Fixes

Fixes #254
