### PR TITLE
Drop Python 3.9 support (EOL Oct 2025)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.13"]
+        python-version: ["3.10", "3.13"]
 
     steps:
     - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 name = "jupyter-resource-usage"
 description = "Jupyter Extension to show resource usage"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "Jupyter Development Team" },
 ]
@@ -30,7 +30,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Bumps minimum Python to 3.10 in the CI matrix and `pyproject.toml` to fix the hatch installation failure.

Changes:
- `.github/workflows/tests.yml`: `"3.9"` → `"3.10"` in matrix
- `pyproject.toml`: `requires-python` bumped to `>=3.10`, removed 3.9 classifier

Issue #260